### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,27 @@
-# PiDiC
+![](https://heatbadger.now.sh/github/readme/contributte/pidic/?deprecated=1)
 
-[![Phalconist](https://phalconist.com/phalette/pidic/default.svg)](https://phalconist.com/phalette/pidic)
-[![Build Status](https://img.shields.io/travis/phalette/pidic.svg?style=flat-square)](https://travis-ci.org/phalette/pidic)
-[![Code coverage](https://img.shields.io/coveralls/phalette/pidic.svg?style=flat-square)](https://coveralls.io/r/phalette/pidic)
-[![Downloads this Month](https://img.shields.io/packagist/dt/phalette/pidic.svg?style=flat-square)](https://packagist.org/packages/phalette/pidic)
-[![Latest stable](https://img.shields.io/packagist/v/phalette/pidic.svg?style=flat-square)](https://packagist.org/packages/phalette/pidic)
-[![HHVM Status](https://img.shields.io/hhvm/phalette/pidic.svg?style=flat-square)](http://hhvm.h4cc.de/package/phalette/pidic)
+<p align=center>
+    <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
+    <a href="https://bit.ly/cttfo"><img src="https://badgen.net/badge/support/forum/yellow"></a>
+    <a href="https://contributte.org/partners.html"><img src="https://badgen.net/badge/sponsor/donations/F96854"></a>
+</p>
+
+<p align=center>
+    Website 🚀 <a href="https://contributte.org">contributte.org</a> | Contact 👨🏻‍💻 <a href="https://f3l1x.io">f3l1x.io</a> | Twitter 🐦 <a href="https://twitter.com/contributte">@contributte</a>
+</p>
+
+## Disclaimer
+
+| :warning: | This project is no longer being maintained.
+|---|---|
+
+| Composer | [`phalette/pidic`](https://packagist.org/packages/phalette/pidic) |
+|---|------------------------------------------------------------|
+| Version | ![](https://badgen.net/packagist/v/phalette/pidic)      |
+| PHP | ![](https://badgen.net/packagist/php/phalette/pidic)    |
+| License | ![](https://badgen.net/github/license/contributte/pidic)   |
+
+## About
 
 PiDiC is an adapter over [Nette\Di\Container](https://api.nette.org/2.3/Nette.DI.Container.html).
 
@@ -130,3 +146,16 @@ Please read articles at Nette documentation:
 But the main article is:
 
 * [Extensions](https://doc.nette.org/en/2.3/di-extensions)
+
+## Development
+
+This package was maintained by these authors.
+
+<a href="https://github.com/f3l1x">
+  <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
+</a>
+
+-----
+
+Consider to [support](https://contributte.org/partners.html) **contributte** development team.
+Also thank you for using this package.


### PR DESCRIPTION
## Summary

This PR converts the repository to archive style following the standard Contributte archive template:

- Added deprecation badge with `?deprecated=1` parameter
- Added disclaimer section with warning about project no longer being maintained
- Added Composer package info table with badges
- Updated Development section to past tense ("was maintained")
- Preserved all original documentation for reference

## Changes

- Updated README.md with archive template (Option B - no replacement package)
- Repository: contributte/pidic
- Package: phalette/pidic

## Next Steps

After this PR is merged:
1. Update repository description to: `[DISCONTINUED] Nette Dependency Injection/Container for Phalcon`
2. Archive the repository using: `gh repo archive contributte/pidic --yes`

Generated with Claude Code